### PR TITLE
Updating Github Actions to use latest from Hashicorp

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,27 +7,30 @@ on:
       - master
 
 jobs:
-  tf_fmt:
+  Terraform:
     name: Terraform Plan & Apply
     runs-on: ubuntu-latest
     steps:
 
     - name: Checkout Repo
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
+    - name: Terraform Setup
+      uses: hashicorp/setup-terraform@v1
+      
     - name: Terraform Init
-      uses: hashicorp/terraform-github-actions/init@v0.4.0
+      run: terraform init
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TF_ACTION_WORKING_DIR: '.'
         AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY:  ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-    - name: Terraform Validate
-      uses: hashicorp/terraform-github-actions/validate@v0.3.7
+        
+    - name: Terraform validate
+      run: terraform validate
 
     - name: Terraform Apply
-      uses: hashicorp/terraform-github-actions/apply@v0.4.0
+      run: terraform apply -auto-approve
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TF_ACTION_WORKING_DIR: '.'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,27 +7,30 @@ on:
       - master
 
 jobs:
-  tf_fmt:
-    name: Terraform Plan
+  Terraform:
+    name: Terraform Plan & Apply
     runs-on: ubuntu-latest
     steps:
 
     - name: Checkout Repo
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
+    - name: Terraform Setup
+      uses: hashicorp/setup-terraform@v1
+      
     - name: Terraform Init
-      uses: hashicorp/terraform-github-actions/init@v0.4.0
+      run: terraform init
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TF_ACTION_WORKING_DIR: '.'
         AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY:  ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
+      
     - name: Terraform Validate
-      uses: hashicorp/terraform-github-actions/validate@v0.3.7
+      run: terraform validate
 
     - name: Terraform Plan
-      uses: hashicorp/terraform-github-actions/plan@v0.4.0
+      run: terraform plan
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TF_ACTION_WORKING_DIR: '.'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,16 +8,16 @@ on:
 
 jobs:
   Terraform:
-    name: Terraform Plan & Apply
+    name: Terraform Plan
     runs-on: ubuntu-latest
     steps:
 
     - name: Checkout Repo
       uses: actions/checkout@v2
-
+    
     - name: Terraform Setup
       uses: hashicorp/setup-terraform@v1
-      
+
     - name: Terraform Init
       run: terraform init
       env:
@@ -25,7 +25,7 @@ jobs:
         TF_ACTION_WORKING_DIR: '.'
         AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY:  ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      
+
     - name: Terraform Validate
       run: terraform validate
 


### PR DESCRIPTION
Thanks for putting this together.  I ran into an issue where the version of Terraform I had locally was newer than the version in the Github Action.  When I found the Hashicorp docs they mentioned there's a newer Github Action available so I updated the code to reflect the new Action.

Reference: https://www.terraform.io/docs/github-actions/index.html
